### PR TITLE
兼容 React17，解决 npm 安装时报版本不匹配的错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "typescript": "^3.3.3"
   },
   "peerDependencies": {
-    "react": "16.x"
+    "react": ">=16.9.0"
   },
   "authors": {
     "name": "chenshuai2144",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21698836/117179533-cbab4200-ae05-11eb-9e43-f0480335fb94.png)
